### PR TITLE
Add the ability to configure key generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use axum_response_cache::CacheLayer;
 async fn main() {
     let mut router = Router::new()
         .route(
-            "/hello/:name",
+            "/hello/{name}",
             get(|Path(name): Path<String>| async move { format!("Hello, {name}!") })
                 // this will cache responses with each `:name` for 60 seconds.
                 .layer(CacheLayer::with_lifespan(60)),


### PR DESCRIPTION
Reasons to do this may include caching based on:

-  accept header if the endoint serves HTML/XML/json
- any other header (for example to provide different content to logged in or out users)
- only specific querystring parameters. This allows you to respect important parameters and ignore tracking parameters

This PR works for my needs, and on the face of it the existing interface is unchanged. Tests all pass, including a new one to demonstrate the feature. Happy to hear any suggestions on code style or better ways to do the same thing.